### PR TITLE
Refactor sending error messages

### DIFF
--- a/src/execution_result/error.rs
+++ b/src/execution_result/error.rs
@@ -1,0 +1,14 @@
+use super::{ExecutionResult, ResultType};
+
+pub struct ErrorResult {
+    pub message: String,
+}
+
+impl ExecutionResult for ErrorResult {
+    fn get_result_type(&self) -> super::ResultType {
+        ResultType::SimpleError
+    }
+    fn to_string(&self) -> String {
+        format!("ERR {}", self.message).to_string()
+    }
+}

--- a/src/execution_result/mod.rs
+++ b/src/execution_result/mod.rs
@@ -1,5 +1,7 @@
 mod base;
 pub use base::ExecutionResult;
+mod error;
+pub use error::ErrorResult;
 mod ping;
 pub use ping::PingResult;
 mod set;

--- a/src/execution_result/types.rs
+++ b/src/execution_result/types.rs
@@ -2,12 +2,14 @@ use std::fmt::Display;
 
 pub enum ResultType {
     SimpleString,
+    SimpleError,
 }
 
 impl Display for ResultType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             ResultType::SimpleString => "+",
+            ResultType::SimpleError => "-",
         };
         write!(f, "{}", s)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,8 @@
+use crate::execution_result::ExecutionResult;
+
 use super::command::CommandFactory;
 use super::error::RequestError;
+use super::execution_result::ErrorResult;
 use log;
 use regex::Regex;
 use std::collections::HashMap;
@@ -12,9 +15,11 @@ pub fn load_data_store() -> HashMap<String, String> {
 }
 
 pub fn handle_error(mut stream: TcpStream, error_message: String) {
-    log::error!("Error: {}", error_message);
-    let out = format!("-ERR {}\r\n", error_message);
-    stream.write_all(&out.as_bytes()).unwrap();
+    log::error!("Error: {}", &error_message);
+    let err = ErrorResult {
+        message: error_message,
+    };
+    stream.write_all(err.serialise().as_bytes()).unwrap();
 }
 
 pub fn handle_connection(


### PR DESCRIPTION
Make errors a type of `ExecutionResult` to unify serialisation.