### PR TITLE
Return NULL for GET command with non-existent keys

### DIFF
--- a/src/command/get.rs
+++ b/src/command/get.rs
@@ -27,7 +27,10 @@ impl Command for GetCommand {
     fn execute(&self, data_store: &mut HashMap<String, String>) -> Box<dyn ExecutionResult> {
         let value = data_store.get(&self.key);
         Box::new(GetResult {
-            value: value.unwrap().clone(),
+            value: match value {
+                Some(v) => Some(v.clone()),
+                None => None,
+            },
         })
     }
 }
@@ -61,11 +64,19 @@ mod test {
     }
 
     #[test]
-    fn should_get_value() {
+    fn should_get_value_if_key_exists() {
         let cmd = GetCommand::new(vec!["foo".to_string()]).unwrap();
         let mut ds = HashMap::<String, String>::new();
         ds.insert("foo".to_string(), "bar".to_string());
         let result = cmd.execute(&mut ds);
         assert_eq!(result.to_string(), "bar".to_string());
+    }
+
+    #[test]
+    fn should_return_null_if_key_does_not_exist() {
+        let cmd = GetCommand::new(vec!["foo".to_string()]).unwrap();
+        let mut ds = HashMap::<String, String>::new();
+        let result = cmd.execute(&mut ds);
+        assert_eq!(result.to_string(), "".to_string());
     }
 }

--- a/src/execution_result/get.rs
+++ b/src/execution_result/get.rs
@@ -1,14 +1,20 @@
 use super::{ExecutionResult, ResultType};
 
 pub struct GetResult {
-    pub value: String,
+    pub value: Option<String>,
 }
 
 impl ExecutionResult for GetResult {
     fn get_result_type(&self) -> super::ResultType {
-        ResultType::SimpleString
+        match self.value {
+            Some(_) => ResultType::SimpleString,
+            None => ResultType::Null,
+        }
     }
     fn to_string(&self) -> String {
-        self.value.clone()
+        match &self.value {
+            Some(v) => v.clone(),
+            None => "".to_string(),
+        }
     }
 }

--- a/src/execution_result/types.rs
+++ b/src/execution_result/types.rs
@@ -2,12 +2,14 @@ use std::fmt::Display;
 
 pub enum ResultType {
     SimpleString,
+    Null,
 }
 
 impl Display for ResultType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             ResultType::SimpleString => "+",
+            ResultType::Null => "_",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
Fixes what was missed out in #24. When a GET command tries to fetch a non-existent key, a `null` message should be returned.