### PR TITLE
Implement INCRBY command

### DIFF
--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -101,10 +101,7 @@ impl IncrbyCommand {
                 key: tokens[0].clone(),
                 op: IntOp::new(&(increment * multiplier as i64)),
             })),
-            Err(_) => Err(RequestError::InvalidCommandBody(format!(
-                "Failed to parse parameter `increment`. Value: `{}`",
-                tokens[1]
-            ))),
+            Err(_) => Err(RequestError::InvalidIntValue),
         }
     }
 }
@@ -193,6 +190,7 @@ mod test {
     mod test_incrby {
         use super::super::IncrbyCommand;
         use crate::command::Command;
+        use crate::error::RequestError;
         use crate::{command::int_op::OpMultiplier, error::IncrCommandError};
         use std::collections::HashMap;
 
@@ -223,10 +221,7 @@ mod test {
                 OpMultiplier::INCR,
             ) {
                 Ok(_) => panic!("should not be ok"),
-                Err(e) => assert_eq!(
-                    e.to_string(),
-                    "invalid command body. Details: Failed to parse parameter `increment`. Value: `bar`".to_string()
-                ),
+                Err(e) => assert_eq!(e.to_string(), RequestError::InvalidIntValue.to_string()),
             }
         }
 

--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -3,6 +3,11 @@ use crate::error::{IncrCommandError, RequestError};
 use crate::execution_result::{ExecutionResult, IntOpResult};
 use std::collections::HashMap;
 
+pub enum OpMultiplier {
+    INCR = 1,
+    DECR = -1,
+}
+
 #[derive(Debug)]
 struct IntOp {
     value: i64,
@@ -51,7 +56,7 @@ pub struct IncrCommand {
 }
 
 impl IncrCommand {
-    pub fn new(tokens: Vec<String>, amount: i64) -> Result<Box<Self>, RequestError> {
+    pub fn new(tokens: Vec<String>, amount: OpMultiplier) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 1 {
             return Err(RequestError::InvalidCommandBody(format!(
                 "Expected number of tokens: {}, received: {}",
@@ -61,7 +66,7 @@ impl IncrCommand {
         }
         Ok(Box::new(IncrCommand {
             key: tokens[0].clone(),
-            op: IntOp::new(&amount),
+            op: IntOp::new(&(amount as i64)),
         }))
     }
 }
@@ -75,19 +80,60 @@ impl Command for IncrCommand {
     }
 }
 
+#[derive(Debug)]
+pub struct IncrbyCommand {
+    key: String,
+    op: IntOp,
+}
+
+impl IncrbyCommand {
+    pub fn new(tokens: Vec<String>, multiplier: OpMultiplier) -> Result<Box<Self>, RequestError> {
+        if tokens.len() != 2 {
+            return Err(RequestError::InvalidCommandBody(format!(
+                "Expected number of tokens: {}, received: {}",
+                2,
+                tokens.len()
+            )));
+        }
+
+        match tokens[1].parse::<i64>() {
+            Ok(increment) => Ok(Box::new(IncrbyCommand {
+                key: tokens[0].clone(),
+                op: IntOp::new(&(increment * multiplier as i64)),
+            })),
+            Err(_) => Err(RequestError::InvalidCommandBody(format!(
+                "Failed to parse parameter `increment`. Value: `{}`",
+                tokens[1]
+            ))),
+        }
+    }
+}
+
+impl Command for IncrbyCommand {
+    fn execute(
+        &self,
+        data_store: &mut HashMap<String, String>,
+    ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
+        _execute(&self.op, &self.key, data_store)
+    }
+}
+
 #[cfg(test)]
 mod test {
     mod test_incr {
         use std::collections::HashMap;
 
-        use crate::command::Command;
+        use crate::command::{int_op::OpMultiplier, Command};
 
         use super::super::IncrCommand;
         use crate::error::IncrCommandError;
 
         #[test]
         fn should_accept_exactly_one_token() {
-            match IncrCommand::new(vec!["foo".to_string(), "bar".to_string()], 1) {
+            match IncrCommand::new(
+                vec!["foo".to_string(), "bar".to_string()],
+                OpMultiplier::INCR,
+            ) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => {
                     assert_eq!(
@@ -97,7 +143,7 @@ mod test {
                     );
                 }
             }
-            match IncrCommand::new(vec!["foo".to_string()], 1) {
+            match IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR) {
                 Ok(v) => {
                     assert_eq!(v.key, "foo".to_string());
                 }
@@ -107,7 +153,7 @@ mod test {
 
         #[test]
         fn should_insert_value_when_key_is_not_set() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], 1).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             assert!(ds.get(&"foo".to_string()).is_none());
             cmd.execute(&mut ds).unwrap();
@@ -116,7 +162,7 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_is_not_int() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], 1).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), "bar".to_string());
             assert!(cmd.execute(&mut ds).is_err());
@@ -124,7 +170,7 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_incr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], 1).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MAX.to_string());
             match cmd.execute(&mut ds) {
@@ -135,9 +181,62 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_decr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], -1).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::DECR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MIN.to_string());
+            match cmd.execute(&mut ds) {
+                Ok(_) => panic!("should not be ok"),
+                Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),
+            }
+        }
+    }
+    mod test_incrby {
+        use super::super::IncrbyCommand;
+        use crate::command::Command;
+        use crate::{command::int_op::OpMultiplier, error::IncrCommandError};
+        use std::collections::HashMap;
+
+        #[test]
+        fn should_accept_exactly_two_tokens() {
+            match IncrbyCommand::new(vec!["foo".to_string()], OpMultiplier::INCR) {
+                Ok(_) => panic!("should not be ok"),
+                Err(e) => {
+                    assert_eq!(
+                        e.to_string(),
+                        "invalid command body. Details: Expected number of tokens: 2, received: 1"
+                            .to_string()
+                    );
+                }
+            }
+            match IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], OpMultiplier::INCR) {
+                Ok(v) => {
+                    assert_eq!(v.key, "foo".to_string());
+                }
+                Err(_) => panic!("should be ok"),
+            }
+        }
+
+        #[test]
+        fn should_reject_non_int_increment() {
+            match IncrbyCommand::new(
+                vec!["foo".to_string(), "bar".to_string()],
+                OpMultiplier::INCR,
+            ) {
+                Ok(_) => panic!("should not be ok"),
+                Err(e) => assert_eq!(
+                    e.to_string(),
+                    "invalid command body. Details: Failed to parse parameter `increment`. Value: `bar`".to_string()
+                ),
+            }
+        }
+
+        #[test]
+        fn should_throw_error_when_value_overflows_incr() {
+            let cmd =
+                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], OpMultiplier::INCR)
+                    .unwrap();
+            let mut ds = HashMap::<String, String>::new();
+            ds.insert("foo".to_string(), i64::MAX.to_string());
             match cmd.execute(&mut ds) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,7 +8,7 @@ use ping::PingCommand;
 mod set;
 use set::SetCommand;
 mod int_op;
-use int_op::IncrCommand;
+use int_op::{IncrCommand, IncrbyCommand, OpMultiplier};
 mod types;
 use std::str::FromStr;
 use types::CommandType;
@@ -34,11 +34,15 @@ impl CommandFactory {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::INCR => match IncrCommand::new(body, 1) {
+                CommandType::INCR => match IncrCommand::new(body, OpMultiplier::INCR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::DECR => match IncrCommand::new(body, -1) {
+                CommandType::DECR => match IncrCommand::new(body, OpMultiplier::DECR) {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(e),
+                },
+                CommandType::INCRBY => match IncrbyCommand::new(body, OpMultiplier::INCR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -6,6 +6,7 @@ pub enum CommandType {
     GET,
     INCR,
     DECR,
+    INCRBY,
 }
 
 impl FromStr for CommandType {
@@ -18,6 +19,7 @@ impl FromStr for CommandType {
             "GET" => Ok(CommandType::GET),
             "INCR" => Ok(CommandType::INCR),
             "DECR" => Ok(CommandType::DECR),
+            "INCRBY" => Ok(CommandType::INCRBY),
             _ => Err(()),
         }
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -10,6 +10,8 @@ pub enum RequestError {
     InvalidCommand(String, String),
     #[error("invalid command body. Details: {0}")]
     InvalidCommandBody(String),
+    #[error("value is not an integer or out of range")]
+    InvalidIntValue,
     #[error("unknown request error")]
     Unknown,
 }


### PR DESCRIPTION
Closes #16.

Note that `RequestError::InvalidIntValue` is a duplicate of `IncrCommandError::InvalidValue` as the error message needs to be the same when the `increment` parameter is not a valid integer. This is the current behaviour of redis.