### PR TITLE
Remove error message prefix

### DIFF
--- a/src/execution_result/error.rs
+++ b/src/execution_result/error.rs
@@ -9,6 +9,6 @@ impl ExecutionResult for ErrorResult {
         ResultType::SimpleError
     }
     fn to_string(&self) -> String {
-        format!("ERR {}", self.message).to_string()
+        self.message.clone()
     }
 }


### PR DESCRIPTION
Remove the prefix to align with error messages in redis.

Result:
```sh
$ redis-cli DECRBY foo 100000000000000000000000000000000
(error) value is not an integer or out of range
```