### PR TITLE
Rework INT operations

### DIFF
--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -3,48 +3,26 @@ use crate::error::{IncrCommandError, RequestError};
 use crate::execution_result::{ExecutionResult, IntOpResult};
 use std::collections::HashMap;
 
-pub enum OpMultiplier {
-    INCR = 1,
-    DECR = -1,
-}
-
-#[derive(Debug)]
-struct IntOp {
-    value: i64,
-}
-
-impl IntOp {
-    pub fn new(value: &i64) -> Self {
-        Self { value: *value }
-    }
-
-    pub fn execute(
-        &self,
-        key: &String,
-        data_store: &mut HashMap<String, String>,
-    ) -> Result<i64, ()> {
-        let default = "0".to_string();
-        let curr_value = data_store.get(key).unwrap_or(&default);
-        match curr_value.parse::<i64>() {
-            Ok(v) => match v.checked_add(self.value) {
-                Some(updated) => {
-                    data_store.insert(key.clone(), updated.to_string());
-                    Ok(updated)
-                }
-                None => Err(()),
-            },
-            Err(_) => Err(()),
-        }
-    }
+pub enum NumOperator {
+    INCR,
+    DECR,
 }
 
 fn _execute(
-    op: &IntOp,
     key: &String,
+    value: i64,
     data_store: &mut HashMap<String, String>,
 ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-    match op.execute(key, data_store) {
-        Ok(v) => Ok(Box::new(IntOpResult { value: v })),
+    let default = "0".to_string();
+    let curr_value = data_store.get(key).unwrap_or(&default);
+    match curr_value.parse::<i64>() {
+        Ok(v) => match v.checked_add(value) {
+            Some(updated) => {
+                data_store.insert(key.clone(), updated.to_string());
+                Ok(Box::new(IntOpResult { value: updated }))
+            }
+            None => Err(Box::new(IncrCommandError::InvalidValue)),
+        },
         Err(_) => Err(Box::new(IncrCommandError::InvalidValue)),
     }
 }
@@ -52,11 +30,11 @@ fn _execute(
 #[derive(Debug)]
 pub struct IncrCommand {
     key: String,
-    op: IntOp,
+    value: i64,
 }
 
 impl IncrCommand {
-    pub fn new(tokens: Vec<String>, amount: OpMultiplier) -> Result<Box<Self>, RequestError> {
+    pub fn new(tokens: Vec<String>, op: NumOperator) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 1 {
             return Err(RequestError::InvalidCommandBody(format!(
                 "Expected number of tokens: {}, received: {}",
@@ -66,7 +44,10 @@ impl IncrCommand {
         }
         Ok(Box::new(IncrCommand {
             key: tokens[0].clone(),
-            op: IntOp::new(&(amount as i64)),
+            value: match op {
+                NumOperator::DECR => -1,
+                NumOperator::INCR => 1,
+            },
         }))
     }
 }
@@ -76,18 +57,18 @@ impl Command for IncrCommand {
         &self,
         data_store: &mut HashMap<String, String>,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        _execute(&self.op, &self.key, data_store)
+        _execute(&self.key, self.value, data_store)
     }
 }
 
 #[derive(Debug)]
 pub struct IncrbyCommand {
     key: String,
-    op: IntOp,
+    value: i64,
 }
 
 impl IncrbyCommand {
-    pub fn new(tokens: Vec<String>, multiplier: OpMultiplier) -> Result<Box<Self>, RequestError> {
+    pub fn new(tokens: Vec<String>, op: NumOperator) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 2 {
             return Err(RequestError::InvalidCommandBody(format!(
                 "Expected number of tokens: {}, received: {}",
@@ -97,10 +78,19 @@ impl IncrbyCommand {
         }
 
         match tokens[1].parse::<i64>() {
-            Ok(increment) => Ok(Box::new(IncrbyCommand {
-                key: tokens[0].clone(),
-                op: IntOp::new(&(increment * multiplier as i64)),
-            })),
+            Ok(increment) => {
+                let value = match op {
+                    NumOperator::DECR => match increment.checked_neg() {
+                        Some(v) => v,
+                        None => return Err(RequestError::InvalidIntValue),
+                    },
+                    NumOperator::INCR => increment,
+                };
+                Ok(Box::new(IncrbyCommand {
+                    key: tokens[0].clone(),
+                    value: value,
+                }))
+            }
             Err(_) => Err(RequestError::InvalidIntValue),
         }
     }
@@ -111,7 +101,7 @@ impl Command for IncrbyCommand {
         &self,
         data_store: &mut HashMap<String, String>,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        _execute(&self.op, &self.key, data_store)
+        _execute(&self.key, self.value, data_store)
     }
 }
 
@@ -120,7 +110,7 @@ mod test {
     mod test_incr {
         use std::collections::HashMap;
 
-        use crate::command::{int_op::OpMultiplier, Command};
+        use crate::command::{int_op::NumOperator, Command};
 
         use super::super::IncrCommand;
         use crate::error::IncrCommandError;
@@ -129,7 +119,7 @@ mod test {
         fn should_accept_exactly_one_token() {
             match IncrCommand::new(
                 vec!["foo".to_string(), "bar".to_string()],
-                OpMultiplier::INCR,
+                NumOperator::INCR,
             ) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => {
@@ -140,7 +130,7 @@ mod test {
                     );
                 }
             }
-            match IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR) {
+            match IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR) {
                 Ok(v) => {
                     assert_eq!(v.key, "foo".to_string());
                 }
@@ -149,8 +139,8 @@ mod test {
         }
 
         #[test]
-        fn should_insert_value_when_key_is_not_set() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
+        fn should_insert_value_when_key_is_not_set_incr() {
+            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             assert!(ds.get(&"foo".to_string()).is_none());
             cmd.execute(&mut ds).unwrap();
@@ -158,8 +148,17 @@ mod test {
         }
 
         #[test]
+        fn should_insert_value_when_key_is_not_set_decr() {
+            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::DECR).unwrap();
+            let mut ds = HashMap::<String, String>::new();
+            assert!(ds.get(&"foo".to_string()).is_none());
+            cmd.execute(&mut ds).unwrap();
+            assert_eq!(ds.get(&"foo".to_string()).unwrap(), &"-1".to_string());
+        }
+
+        #[test]
         fn should_throw_error_when_value_is_not_int() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), "bar".to_string());
             assert!(cmd.execute(&mut ds).is_err());
@@ -167,7 +166,7 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_incr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::INCR).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MAX.to_string());
             match cmd.execute(&mut ds) {
@@ -178,7 +177,7 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_decr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], OpMultiplier::DECR).unwrap();
+            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::DECR).unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MIN.to_string());
             match cmd.execute(&mut ds) {
@@ -191,12 +190,12 @@ mod test {
         use super::super::IncrbyCommand;
         use crate::command::Command;
         use crate::error::RequestError;
-        use crate::{command::int_op::OpMultiplier, error::IncrCommandError};
+        use crate::{command::int_op::NumOperator, error::IncrCommandError};
         use std::collections::HashMap;
 
         #[test]
         fn should_accept_exactly_two_tokens() {
-            match IncrbyCommand::new(vec!["foo".to_string()], OpMultiplier::INCR) {
+            match IncrbyCommand::new(vec!["foo".to_string()], NumOperator::INCR) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => {
                     assert_eq!(
@@ -206,7 +205,7 @@ mod test {
                     );
                 }
             }
-            match IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], OpMultiplier::INCR) {
+            match IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], NumOperator::INCR) {
                 Ok(v) => {
                     assert_eq!(v.key, "foo".to_string());
                 }
@@ -218,7 +217,7 @@ mod test {
         fn should_reject_non_int_increment() {
             match IncrbyCommand::new(
                 vec!["foo".to_string(), "bar".to_string()],
-                OpMultiplier::INCR,
+                NumOperator::INCR,
             ) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), RequestError::InvalidIntValue.to_string()),
@@ -228,7 +227,7 @@ mod test {
         #[test]
         fn should_throw_error_when_value_overflows_incr() {
             let cmd =
-                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], OpMultiplier::INCR)
+                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], NumOperator::INCR)
                     .unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MAX.to_string());
@@ -241,7 +240,7 @@ mod test {
         #[test]
         fn should_throw_error_when_value_overflows_decr() {
             let cmd =
-                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], OpMultiplier::DECR)
+                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], NumOperator::DECR)
                     .unwrap();
             let mut ds = HashMap::<String, String>::new();
             ds.insert("foo".to_string(), i64::MIN.to_string());

--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -109,9 +109,7 @@ impl Command for IncrbyCommand {
 mod test {
     mod test_incr {
         use std::collections::HashMap;
-
         use crate::command::{int_op::NumOperator, Command};
-
         use super::super::IncrCommand;
         use crate::error::IncrCommandError;
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,7 +8,7 @@ use ping::PingCommand;
 mod set;
 use set::SetCommand;
 mod int_op;
-use int_op::{IncrCommand, IncrbyCommand, OpMultiplier};
+use int_op::{IncrCommand, IncrbyCommand, NumOperator};
 mod types;
 use std::str::FromStr;
 use types::CommandType;
@@ -34,19 +34,19 @@ impl CommandFactory {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::INCR => match IncrCommand::new(body, OpMultiplier::INCR) {
+                CommandType::INCR => match IncrCommand::new(body, NumOperator::INCR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::DECR => match IncrCommand::new(body, OpMultiplier::DECR) {
+                CommandType::DECR => match IncrCommand::new(body, NumOperator::DECR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::INCRBY => match IncrbyCommand::new(body, OpMultiplier::INCR) {
+                CommandType::INCRBY => match IncrbyCommand::new(body, NumOperator::INCR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },
-                CommandType::DECRBY => match IncrbyCommand::new(body, OpMultiplier::DECR) {
+                CommandType::DECRBY => match IncrbyCommand::new(body, NumOperator::DECR) {
                     Ok(v) => Ok(v),
                     Err(e) => Err(e),
                 },


### PR DESCRIPTION
`IntOp` is actually redundant. This PR removes the struct and methods.