### PR TITLE
Change the error for incorrect number of command arguments

### DIFF
--- a/src/command/get.rs
+++ b/src/command/get.rs
@@ -11,11 +11,7 @@ pub struct GetCommand {
 impl GetCommand {
     pub fn new(tokens: Vec<String>) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 1 {
-            return Err(RequestError::InvalidCommandBody(format!(
-                "Expected number of tokens: {}, received: {}",
-                1,
-                tokens.len()
-            )));
+            return Err(RequestError::IncorrectArgCount);
         }
         Ok(Box::new(GetCommand {
             key: tokens[0].clone(),
@@ -59,8 +55,7 @@ mod test {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    "invalid command body. Details: Expected number of tokens: 1, received: 2"
-                        .to_string()
+                    "ERR wrong number of arguments for command".to_string()
                 );
             }
         }

--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -58,11 +58,7 @@ pub struct IncrCommand {
 impl IncrCommand {
     pub fn new(tokens: Vec<String>, amount: OpMultiplier) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 1 {
-            return Err(RequestError::InvalidCommandBody(format!(
-                "Expected number of tokens: {}, received: {}",
-                1,
-                tokens.len()
-            )));
+            return Err(RequestError::IncorrectArgCount);
         }
         Ok(Box::new(IncrCommand {
             key: tokens[0].clone(),
@@ -89,11 +85,7 @@ pub struct IncrbyCommand {
 impl IncrbyCommand {
     pub fn new(tokens: Vec<String>, multiplier: OpMultiplier) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 2 {
-            return Err(RequestError::InvalidCommandBody(format!(
-                "Expected number of tokens: {}, received: {}",
-                2,
-                tokens.len()
-            )));
+            return Err(RequestError::IncorrectArgCount);
         }
 
         match tokens[1].parse::<i64>() {
@@ -135,8 +127,7 @@ mod test {
                 Err(e) => {
                     assert_eq!(
                         e.to_string(),
-                        "invalid command body. Details: Expected number of tokens: 1, received: 2"
-                            .to_string()
+                        "ERR wrong number of arguments for command".to_string()
                     );
                 }
             }
@@ -201,8 +192,7 @@ mod test {
                 Err(e) => {
                     assert_eq!(
                         e.to_string(),
-                        "invalid command body. Details: Expected number of tokens: 2, received: 1"
-                            .to_string()
+                        "ERR wrong number of arguments for command".to_string()
                     );
                 }
             }

--- a/src/command/ping.rs
+++ b/src/command/ping.rs
@@ -9,11 +9,7 @@ pub struct PingCommand;
 impl PingCommand {
     pub fn new(tokens: Vec<String>) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 0 {
-            return Err(RequestError::InvalidCommandBody(format!(
-                "Expected number of tokens: {}, received: {}",
-                1,
-                tokens.len()
-            )));
+            return Err(RequestError::IncorrectArgCount);
         }
         Ok(Box::new(PingCommand {}))
     }

--- a/src/command/set.rs
+++ b/src/command/set.rs
@@ -12,11 +12,7 @@ pub struct SetCommand {
 impl SetCommand {
     pub fn new(tokens: Vec<String>) -> Result<Box<Self>, RequestError> {
         if tokens.len() != 2 {
-            return Err(RequestError::InvalidCommandBody(format!(
-                "Expected number of tokens: {}, received: {}",
-                2,
-                tokens.len()
-            )));
+            return Err(RequestError::IncorrectArgCount);
         }
         Ok(Box::new(SetCommand {
             key: tokens[0].clone(),
@@ -50,8 +46,7 @@ mod test {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    "invalid command body. Details: Expected number of tokens: 2, received: 1"
-                        .to_string()
+                    "ERR wrong number of arguments for command".to_string()
                 );
             }
         }
@@ -64,8 +59,7 @@ mod test {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    "invalid command body. Details: Expected number of tokens: 2, received: 3"
-                        .to_string()
+                    "ERR wrong number of arguments for command".to_string()
                 );
             }
         }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -12,6 +12,8 @@ pub enum RequestError {
     InvalidCommandBody(String),
     #[error("value is not an integer or out of range")]
     InvalidIntValue,
+    #[error("ERR wrong number of arguments for command")]
+    IncorrectArgCount,
     #[error("unknown request error")]
     Unknown,
 }


### PR DESCRIPTION
Change the error message to `ERR wrong number of arguments for command` to match the error message in redis.