### PR TITLE
Extend data store with redis entry to support different data types

### DIFF
--- a/src/command/base.rs
+++ b/src/command/base.rs
@@ -1,9 +1,9 @@
+use crate::data_store::DataStore;
 use crate::execution_result::ExecutionResult;
-use std::collections::HashMap;
 
 pub trait Command {
     fn execute(
         &self,
-        data_store: &mut HashMap<String, String>,
+        data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>>;
 }

--- a/src/command/get.rs
+++ b/src/command/get.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
+use crate::data_store::DataStore;
 use crate::error::RequestError;
 use crate::execution_result::{ExecutionResult, GetResult};
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct GetCommand {
@@ -26,9 +26,9 @@ impl GetCommand {
 impl Command for GetCommand {
     fn execute(
         &self,
-        data_store: &mut HashMap<String, String>,
+        data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        let value = data_store.get(&self.key);
+        let value = data_store.get_string_store().get(&self.key);
         Ok(Box::new(GetResult {
             value: match value {
                 Some(v) => Some(v.clone()),
@@ -40,7 +40,7 @@ impl Command for GetCommand {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use crate::data_store::DataStore;
 
     use crate::command::Command;
 
@@ -69,8 +69,9 @@ mod test {
     #[test]
     fn should_get_value_if_key_exists() {
         let cmd = GetCommand::new(vec!["foo".to_string()]).unwrap();
-        let mut ds = HashMap::<String, String>::new();
-        ds.insert("foo".to_string(), "bar".to_string());
+        let mut ds = DataStore::new();
+        ds.get_string_store()
+            .insert("foo".to_string(), "bar".to_string());
         let result = cmd.execute(&mut ds);
         assert_eq!(result.unwrap().to_string(), "bar".to_string());
     }
@@ -78,7 +79,7 @@ mod test {
     #[test]
     fn should_return_null_if_key_does_not_exist() {
         let cmd = GetCommand::new(vec!["foo".to_string()]).unwrap();
-        let mut ds = HashMap::<String, String>::new();
+        let mut ds = DataStore::new();
         let result = cmd.execute(&mut ds);
         assert_eq!(result.unwrap().to_string(), "".to_string());
     }

--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -1,6 +1,6 @@
 use crate::command::Command;
-use crate::data_store::{DataStore, RedisEntry, RedisEntryType};
-use crate::error::{ExecutionError, IncrCommandError, InternalError, RequestError};
+use crate::data_store::DataStore;
+use crate::error::{IncrCommandError, RequestError};
 use crate::execution_result::{ExecutionResult, IntOpResult};
 
 pub enum NumOperator {
@@ -13,30 +13,23 @@ fn _execute(
     value: i64,
     data_store: &mut DataStore,
 ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-    if !data_store.contains_key(key) {
-        data_store.insert(key.clone(), RedisEntry::create_string(&"0".to_string()));
-    }
-    let entry = data_store.get_mut(key).unwrap();
-    match entry.type_ {
-        RedisEntryType::String => {
-            match &entry.string {
-                Some(curr_value) => match curr_value.parse::<i64>() {
-                    Ok(v) => match v.checked_add(value) {
-                        Some(updated) => {
-                            entry.string = Some(updated.to_string());
-                            Ok(Box::new(IntOpResult { value: updated }))
-                        }
-                        None => Err(Box::new(IncrCommandError::InvalidValue)),
-                    },
-                    Err(_) => Err(Box::new(IncrCommandError::InvalidValue)),
-                },
-                None => {
-                    log::error!("Integration error at key '{}': expecting type 'String' but data is not found", key);
-                    Err(Box::new(InternalError::Error))
-                }
+    let default = "0".to_string();
+    let curr_value = match data_store.get_string(key) {
+        Ok(op) => match op {
+            Some(v) => v,
+            None => &default,
+        },
+        Err(e) => return Err(e),
+    };
+    match curr_value.parse::<i64>() {
+        Ok(v) => match v.checked_add(value) {
+            Some(updated) => {
+                let _ = data_store.set_string(key, &updated.to_string());
+                Ok(Box::new(IntOpResult { value: updated }))
             }
-        }
-        _ => Err(Box::new(ExecutionError::IncorrectType)),
+            None => Err(Box::new(IncrCommandError::InvalidValue)),
+        },
+        Err(_) => Err(Box::new(IncrCommandError::InvalidValue)),
     }
 }
 
@@ -114,7 +107,7 @@ impl Command for IncrbyCommand {
 mod test {
     mod test_incr {
         use crate::command::{int_op::NumOperator, Command};
-        use crate::data_store::{DataStore, RedisEntry};
+        use crate::data_store::DataStore;
 
         use super::super::IncrCommand;
         use crate::error::IncrCommandError;
@@ -143,47 +136,39 @@ mod test {
 
         #[test]
         fn should_insert_value_when_key_is_not_set() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
+            let key = "foo".to_string();
+            let cmd = IncrCommand::new(vec![key.clone()], NumOperator::INCR).unwrap();
             let mut ds = DataStore::new();
-            assert!(ds.get(&"foo".to_string()).is_none());
+            assert!(ds.get_string(&key).unwrap().is_none());
             cmd.execute(&mut ds).unwrap();
-            assert_eq!(
-                ds.get(&"foo".to_string()).unwrap().string.as_ref().unwrap(),
-                &"1".to_string()
-            );
+            assert_eq!(ds.get_string(&key).unwrap().unwrap(), &"1".to_string());
         }
 
         #[test]
         fn should_insert_value_when_key_is_not_set_decr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::DECR).unwrap();
+            let key = "foo".to_string();
+            let cmd = IncrCommand::new(vec![key.clone()], NumOperator::DECR).unwrap();
             let mut ds = DataStore::new();
-            assert!(ds.get(&"foo".to_string()).is_none());
+            assert!(ds.get_string(&key).unwrap().is_none());
             cmd.execute(&mut ds).unwrap();
-            assert_eq!(
-                ds.get(&"foo".to_string()).unwrap().string.as_ref().unwrap(),
-                &"-1".to_string()
-            );
+            assert_eq!(ds.get_string(&key).unwrap().unwrap(), &"-1".to_string());
         }
 
         #[test]
         fn should_throw_error_when_value_is_not_int() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
+            let key = "foo".to_string();
+            let cmd = IncrCommand::new(vec![key.clone()], NumOperator::INCR).unwrap();
             let mut ds = DataStore::new();
-            ds.insert(
-                "foo".to_string(),
-                RedisEntry::create_string(&"bar".to_string()),
-            );
+            ds.set_string_overwrite(&key, &"bar".to_string());
             assert!(cmd.execute(&mut ds).is_err());
         }
 
         #[test]
         fn should_throw_error_when_value_overflows_incr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::INCR).unwrap();
+            let key = "foo".to_string();
+            let cmd = IncrCommand::new(vec![key.clone()], NumOperator::INCR).unwrap();
             let mut ds = DataStore::new();
-            ds.insert(
-                "foo".to_string(),
-                RedisEntry::create_string(&i64::MAX.to_string()),
-            );
+            ds.set_string_overwrite(&key, &i64::MAX.to_string());
             match cmd.execute(&mut ds) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),
@@ -192,12 +177,10 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_decr() {
-            let cmd = IncrCommand::new(vec!["foo".to_string()], NumOperator::DECR).unwrap();
+            let key = "foo".to_string();
+            let cmd = IncrCommand::new(vec![key.clone()], NumOperator::DECR).unwrap();
             let mut ds = DataStore::new();
-            ds.insert(
-                "foo".to_string(),
-                RedisEntry::create_string(&i64::MIN.to_string()),
-            );
+            ds.set_string_overwrite(&key, &i64::MIN.to_string());
             match cmd.execute(&mut ds) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),
@@ -207,7 +190,7 @@ mod test {
     mod test_incrby {
         use super::super::IncrbyCommand;
         use crate::command::Command;
-        use crate::data_store::{DataStore, RedisEntry};
+        use crate::data_store::DataStore;
         use crate::error::RequestError;
         use crate::{command::int_op::NumOperator, error::IncrCommandError};
 
@@ -243,14 +226,11 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_incr() {
+            let key = "foo".to_string();
             let cmd =
-                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], NumOperator::INCR)
-                    .unwrap();
+                IncrbyCommand::new(vec![key.clone(), "5".to_string()], NumOperator::INCR).unwrap();
             let mut ds = DataStore::new();
-            ds.insert(
-                "foo".to_string(),
-                RedisEntry::create_string(&i64::MAX.to_string()),
-            );
+            ds.set_string_overwrite(&key, &i64::MAX.to_string());
             match cmd.execute(&mut ds) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),
@@ -259,14 +239,11 @@ mod test {
 
         #[test]
         fn should_throw_error_when_value_overflows_decr() {
+            let key = "foo".to_string();
             let cmd =
-                IncrbyCommand::new(vec!["foo".to_string(), "5".to_string()], NumOperator::DECR)
-                    .unwrap();
+                IncrbyCommand::new(vec![key.clone(), "5".to_string()], NumOperator::DECR).unwrap();
             let mut ds = DataStore::new();
-            ds.insert(
-                "foo".to_string(),
-                RedisEntry::create_string(&i64::MIN.to_string()),
-            );
+            ds.set_string_overwrite(&key, &i64::MIN.to_string());
             match cmd.execute(&mut ds) {
                 Ok(_) => panic!("should not be ok"),
                 Err(e) => assert_eq!(e.to_string(), IncrCommandError::InvalidValue.to_string()),

--- a/src/command/int_op.rs
+++ b/src/command/int_op.rs
@@ -1,6 +1,6 @@
 use crate::command::Command;
 use crate::data_store::{DataStore, RedisEntry};
-use crate::error::{IncrCommandError, RequestError, ExecutionError};
+use crate::error::{ExecutionError, IncrCommandError, RequestError};
 use crate::execution_result::{ExecutionResult, IntOpResult};
 
 pub enum NumOperator {
@@ -19,16 +19,16 @@ fn _execute(
     let entry = data_store.get_mut(key).unwrap();
     match &entry.string {
         Some(curr_value) => match curr_value.parse::<i64>() {
-                Ok(v) => match v.checked_add(value) {
-                    Some(updated) => {
-                        entry.string = Some(updated.to_string());
-                        Ok(Box::new(IntOpResult { value: updated }))
-                    }
-                    None => Err(Box::new(IncrCommandError::InvalidValue)),
-                },
-                Err(_) => Err(Box::new(IncrCommandError::InvalidValue)),
+            Ok(v) => match v.checked_add(value) {
+                Some(updated) => {
+                    entry.string = Some(updated.to_string());
+                    Ok(Box::new(IntOpResult { value: updated }))
+                }
+                None => Err(Box::new(IncrCommandError::InvalidValue)),
             },
-        None => Err(Box::new(ExecutionError::IncorrectType))
+            Err(_) => Err(Box::new(IncrCommandError::InvalidValue)),
+        },
+        None => Err(Box::new(ExecutionError::IncorrectType)),
     }
 }
 

--- a/src/command/ping.rs
+++ b/src/command/ping.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
+use crate::data_store::DataStore;
 use crate::error::RequestError;
 use crate::execution_result::{ExecutionResult, PingResult};
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct PingCommand;
@@ -22,7 +22,7 @@ impl PingCommand {
 impl Command for PingCommand {
     fn execute(
         &self,
-        _: &mut HashMap<String, String>,
+        _: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
         Ok(Box::new(PingResult {}))
     }

--- a/src/command/set.rs
+++ b/src/command/set.rs
@@ -1,5 +1,5 @@
 use crate::command::Command;
-use crate::data_store::DataStore;
+use crate::data_store::{DataStore, RedisEntry};
 use crate::error::RequestError;
 use crate::execution_result::{ExecutionResult, SetResult};
 
@@ -30,9 +30,7 @@ impl Command for SetCommand {
         &self,
         data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        data_store
-            .get_string_store()
-            .insert(self.key.clone(), self.value.clone());
+        data_store.insert(self.key.clone(), RedisEntry::create_string(&self.value));
         Ok(Box::new(SetResult {}))
     }
 }
@@ -82,10 +80,10 @@ mod test {
     fn should_insert_value() {
         let cmd = SetCommand::new(vec!["foo".to_string(), "bar".to_string()]).unwrap();
         let mut ds = DataStore::new();
-        assert!(ds.get_string_store().get(&"foo".to_string()).is_none());
+        assert!(ds.get(&"foo".to_string()).is_none());
         cmd.execute(&mut ds).unwrap();
         assert_eq!(
-            ds.get_string_store().get(&"foo".to_string()).unwrap(),
+            ds.get(&"foo".to_string()).unwrap().string.as_ref().unwrap(),
             &"bar".to_string()
         );
     }

--- a/src/command/set.rs
+++ b/src/command/set.rs
@@ -1,5 +1,5 @@
 use crate::command::Command;
-use crate::data_store::{DataStore, RedisEntry};
+use crate::data_store::DataStore;
 use crate::error::RequestError;
 use crate::execution_result::{ExecutionResult, SetResult};
 
@@ -26,7 +26,7 @@ impl Command for SetCommand {
         &self,
         data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        data_store.insert(self.key.clone(), RedisEntry::create_string(&self.value));
+        data_store.set_string_overwrite(&self.key, &self.value);
         Ok(Box::new(SetResult {}))
     }
 }
@@ -72,13 +72,11 @@ mod test {
 
     #[test]
     fn should_insert_value() {
-        let cmd = SetCommand::new(vec!["foo".to_string(), "bar".to_string()]).unwrap();
+        let key = "foo".to_string();
+        let cmd = SetCommand::new(vec![key.clone(), "bar".to_string()]).unwrap();
         let mut ds = DataStore::new();
-        assert!(ds.get(&"foo".to_string()).is_none());
+        assert!(ds.get_string(&key).unwrap().is_none());
         cmd.execute(&mut ds).unwrap();
-        assert_eq!(
-            ds.get(&"foo".to_string()).unwrap().string.as_ref().unwrap(),
-            &"bar".to_string()
-        );
+        assert_eq!(ds.get_string(&key).unwrap().unwrap(), &"bar".to_string());
     }
 }

--- a/src/command/set.rs
+++ b/src/command/set.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
+use crate::data_store::DataStore;
 use crate::error::RequestError;
 use crate::execution_result::{ExecutionResult, SetResult};
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct SetCommand {
@@ -28,18 +28,18 @@ impl SetCommand {
 impl Command for SetCommand {
     fn execute(
         &self,
-        data_store: &mut HashMap<String, String>,
+        data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        data_store.insert(self.key.clone(), self.value.clone());
+        data_store
+            .get_string_store()
+            .insert(self.key.clone(), self.value.clone());
         Ok(Box::new(SetResult {}))
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
-    use crate::command::Command;
+    use crate::{command::Command, data_store::DataStore};
 
     use super::SetCommand;
 
@@ -81,9 +81,12 @@ mod test {
     #[test]
     fn should_insert_value() {
         let cmd = SetCommand::new(vec!["foo".to_string(), "bar".to_string()]).unwrap();
-        let mut ds = HashMap::<String, String>::new();
-        assert!(ds.get(&"foo".to_string()).is_none());
+        let mut ds = DataStore::new();
+        assert!(ds.get_string_store().get(&"foo".to_string()).is_none());
         cmd.execute(&mut ds).unwrap();
-        assert_eq!(ds.get(&"foo".to_string()).unwrap(), &"bar".to_string());
+        assert_eq!(
+            ds.get_string_store().get(&"foo".to_string()).unwrap(),
+            &"bar".to_string()
+        );
     }
 }

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -37,17 +37,12 @@ pub fn get_data_store() -> DataStore {
 
 #[cfg(test)]
 mod test {
-    use super::{get_data_store, RedisEntry, RedisEntryType};
-    use std::collections::LinkedList;
+    use super::{get_data_store, RedisEntry};
 
     #[test]
     fn test_list_store() {
         let mut ds = get_data_store();
-        let s = RedisEntry {
-            type_: RedisEntryType::List,
-            list: Some(LinkedList::<String>::new()),
-            string: None,
-        };
+        let s = RedisEntry::init_list();
         ds.insert("foo".to_string(), s);
 
         let v = ds.get_mut(&"foo".to_string()).unwrap();

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -1,0 +1,58 @@
+use std::collections::{HashMap, LinkedList};
+
+pub struct DataStore {
+    string: HashMap<String, String>,
+    list: HashMap<String, RedisList>,
+}
+
+impl DataStore {
+    pub fn new() -> Self {
+        DataStore {
+            string: HashMap::<String, String>::new(),
+            list: HashMap::<String, RedisList>::new(),
+        }
+    }
+
+    pub fn get_string_store(&mut self) -> &mut HashMap<String, String> {
+        &mut self.string
+    }
+
+    pub fn get_list_store(&mut self) -> &mut HashMap<String, RedisList> {
+        &mut self.list
+    }
+}
+
+pub struct RedisList {
+    length: usize,
+    items: LinkedList<String>,
+}
+
+impl RedisList {
+    pub fn new() -> Self {
+        RedisList {
+            length: 0,
+            items: LinkedList::<String>::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{DataStore, RedisList};
+
+    #[test]
+    fn test_list_store() {
+        let mut ds = DataStore::new();
+        let s = ds.get_list_store();
+        s.insert("foo".to_string(), RedisList::new());
+
+        let v = s.get_mut(&"foo".to_string()).unwrap();
+        v.items.push_back("aaa".to_string());
+        v.items.push_front("bbb".to_string());
+        v.length += 2;
+
+        let v = s.get(&"foo".to_string()).unwrap();
+        assert_eq!(v.length, 2);
+        assert_eq!(v.items.back().unwrap(), &"aaa".to_string());
+    }
+}

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -24,7 +24,7 @@ impl RedisEntry {
 
     pub fn init_list() -> Self {
         RedisEntry {
-            type_: RedisEntryType::String,
+            type_: RedisEntryType::List,
             string: None,
             list: Some(LinkedList::<String>::new()),
         }

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -1,6 +1,88 @@
+use crate::error::{ExecutionError, InternalError};
 use std::collections::{HashMap, LinkedList};
 
-pub type DataStore = HashMap<String, RedisEntry>;
+pub struct DataStore {
+    ds: HashMap<String, RedisEntry>,
+}
+
+impl DataStore {
+    pub fn new() -> Self {
+        Self { ds: HashMap::new() }
+    }
+
+    pub fn get_string(&self, key: &String) -> Result<Option<&String>, Box<dyn std::error::Error>> {
+        match self.ds.get(key) {
+            Some(entry) => match entry.type_ {
+                RedisEntryType::String => match &entry.string {
+                    Some(v) => Ok(Some(v)),
+                    None => Err(Self::throw_integration_error(key, RedisEntryType::String)),
+                },
+                _ => Err(Box::new(ExecutionError::IncorrectType)),
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub fn set_string_overwrite(&mut self, key: &String, value: &String) {
+        self.ds
+            .insert(key.clone(), RedisEntry::create_string(value));
+    }
+
+    pub fn set_string(
+        &mut self,
+        key: &String,
+        value: &String,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match self.ds.get_mut(key) {
+            Some(entry) => match entry.type_ {
+                RedisEntryType::String => match &entry.string {
+                    Some(_) => {
+                        entry.string = Some(value.clone());
+                        Ok(())
+                    }
+                    None => Err(Self::throw_integration_error(key, RedisEntryType::String)),
+                },
+                _ => Err(Box::new(ExecutionError::IncorrectType)),
+            },
+            None => {
+                self.set_string_overwrite(key, value);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn get_list_mut(
+        &mut self,
+        key: &String,
+    ) -> Result<Option<&mut LinkedList<String>>, Box<dyn std::error::Error>> {
+        match self.ds.get_mut(key) {
+            Some(entry) => match entry.type_ {
+                RedisEntryType::List => match &mut entry.list {
+                    Some(v) => Ok(Some(v)),
+                    None => Err(Self::throw_integration_error(key, RedisEntryType::List)),
+                },
+                _ => Err(Box::new(ExecutionError::IncorrectType)),
+            },
+            None => Ok(None),
+        }
+    }
+
+    fn throw_integration_error(
+        key: &String,
+        expected_type: RedisEntryType,
+    ) -> Box<dyn std::error::Error> {
+        let type_name = match expected_type {
+            RedisEntryType::String => "String",
+            RedisEntryType::List => "List",
+        };
+        log::error!(
+            "Integration error at key '{}': expecting type '{}' but data is not found",
+            key,
+            type_name
+        );
+        return Box::new(InternalError::Error);
+    }
+}
 
 pub enum RedisEntryType {
     String,
@@ -43,13 +125,14 @@ mod test {
     fn test_list_store() {
         let mut ds = get_data_store();
         let s = RedisEntry::init_list();
-        ds.insert("foo".to_string(), s);
+        let key = "foo".to_string();
+        ds.ds.insert(key.clone(), s);
 
-        let v = ds.get_mut(&"foo".to_string()).unwrap();
-        v.list.as_mut().unwrap().push_back("aaa".to_string());
-        v.list.as_mut().unwrap().push_front("bbb".to_string());
+        let v = ds.get_list_mut(&key).unwrap().unwrap();
+        v.push_back("aaa".to_string());
+        v.push_front("bbb".to_string());
 
-        let v = ds.get(&"foo".to_string()).unwrap();
+        let v = ds.ds.get(&"foo".to_string()).unwrap();
         assert_eq!(v.list.as_ref().unwrap().len(), 2);
         assert_eq!(v.list.as_ref().unwrap().back().unwrap(), &"aaa".to_string());
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -25,6 +25,12 @@ pub enum ExecutionError {
 }
 
 #[derive(Error, Debug)]
+pub enum InternalError {
+    #[error("INTERNAL Internal error")]
+    Error,
+}
+
+#[derive(Error, Debug)]
 pub enum IncrCommandError {
     #[error("value is not an integer or out of range")]
     InvalidValue,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -17,6 +17,12 @@ pub enum RequestError {
 }
 
 #[derive(Error, Debug)]
+pub enum ExecutionError {
+    #[error("WRONGTYPE Operation against a key holding the wrong kind of value")]
+    IncorrectType,
+}
+
+#[derive(Error, Debug)]
 pub enum IncrCommandError {
     #[error("value is not an integer or out of range")]
     InvalidValue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod command;
+pub mod data_store;
 pub mod error;
 pub mod execution_result;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use env_logger;
+use redis_rust::data_store;
 use redis_rust::utils;
 use std::net::TcpListener;
 
 fn main() {
     env_logger::init();
-    let mut data_store = utils::load_data_store();
+    let mut data_store = data_store::DataStore::new();
     let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
 
     for stream in listener.incoming() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,16 +3,12 @@ use crate::execution_result::ExecutionResult;
 use super::command::CommandFactory;
 use super::error::RequestError;
 use super::execution_result::ErrorResult;
+use crate::data_store::DataStore;
 use log;
 use regex::Regex;
-use std::collections::HashMap;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::net::TcpStream;
-
-pub fn load_data_store() -> HashMap<String, String> {
-    HashMap::<String, String>::new()
-}
 
 pub fn handle_error(mut stream: TcpStream, error_message: String) {
     log::error!("Error: {}", &error_message);
@@ -22,10 +18,7 @@ pub fn handle_error(mut stream: TcpStream, error_message: String) {
     stream.write_all(err.serialise().as_bytes()).unwrap();
 }
 
-pub fn handle_connection(
-    mut stream: &TcpStream,
-    data_store: &mut HashMap<String, String>,
-) -> Result<(), String> {
+pub fn handle_connection(mut stream: &TcpStream, data_store: &mut DataStore) -> Result<(), String> {
     return match parse_request(stream) {
         Ok(tokens) => {
             log::info!("tokens: {:?}", tokens);


### PR DESCRIPTION
Closes #18.

Data store now becomes a hash map between string keys and `RedisEntry` values. `RedisEntry` is a wrapper for all supported data types, currently `String` and `List`. Only one data type should be available for each entry as one key cannot be mapped to multiple data types. Each entry has a `type_` property to mark the data type of this entry. Some methods are implemented in `DataStore` to simplify access to entries.