### PR TITLE
Move string operations into a module

### DIFF
--- a/src/command/string/get.rs
+++ b/src/command/string/get.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
 use crate::data_store::DataStore;
 use crate::error::RequestError;
-use crate::execution_result::{ExecutionResult, GetResult};
+use crate::execution_result::{string::GetResult, ExecutionResult};
 
 #[derive(Debug)]
 pub struct GetCommand {

--- a/src/command/string/int_op.rs
+++ b/src/command/string/int_op.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
 use crate::data_store::DataStore;
 use crate::error::{IncrCommandError, RequestError};
-use crate::execution_result::{ExecutionResult, IntOpResult};
+use crate::execution_result::{string::IntOpResult, ExecutionResult};
 
 pub enum NumOperator {
     INCR,
@@ -106,7 +106,8 @@ impl Command for IncrbyCommand {
 #[cfg(test)]
 mod test {
     mod test_incr {
-        use crate::command::{int_op::NumOperator, Command};
+        use crate::command::string::NumOperator;
+        use crate::command::Command;
         use crate::data_store::DataStore;
 
         use super::super::IncrCommand;
@@ -182,7 +183,7 @@ mod test {
         use crate::command::Command;
         use crate::data_store::DataStore;
         use crate::error::RequestError;
-        use crate::{command::int_op::NumOperator, error::IncrCommandError};
+        use crate::{command::string::NumOperator, error::IncrCommandError};
 
         #[test]
         fn should_accept_exactly_two_tokens() {

--- a/src/command/string/mod.rs
+++ b/src/command/string/mod.rs
@@ -1,0 +1,6 @@
+mod get;
+pub use get::GetCommand;
+mod int_op;
+pub use int_op::{IncrCommand, IncrbyCommand, NumOperator};
+mod set;
+pub use set::SetCommand;

--- a/src/command/string/set.rs
+++ b/src/command/string/set.rs
@@ -1,7 +1,7 @@
 use crate::command::Command;
 use crate::data_store::DataStore;
 use crate::error::RequestError;
-use crate::execution_result::{ExecutionResult, SetResult};
+use crate::execution_result::{string::SetResult, ExecutionResult};
 
 #[derive(Debug)]
 pub struct SetCommand {

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -1,16 +1,27 @@
 use std::str::FromStr;
 
-pub enum CommandType {
-    PING,
+pub enum StringCommandType {
     SET,
     GET,
     INCR,
     DECR,
     INCRBY,
     DECRBY,
+}
+
+pub enum ListCommandType {
     LPUSH,
     LPOP,
 }
+
+pub enum CommandType {
+    PING,
+    STRING(StringCommandType),
+    LIST(ListCommandType),
+}
+
+const STRING_COMMANDS: &[&str] = &["SET", "GET", "INCR", "DECR", "INCRBY", "DECRBY"];
+const LIST_COMMANDS: &[&str] = &["LPUSH", "LPOP"];
 
 impl FromStr for CommandType {
     type Err = ();
@@ -18,14 +29,38 @@ impl FromStr for CommandType {
     fn from_str(s: &str) -> Result<CommandType, Self::Err> {
         match s {
             "PING" => Ok(CommandType::PING),
-            "SET" => Ok(CommandType::SET),
-            "GET" => Ok(CommandType::GET),
-            "INCR" => Ok(CommandType::INCR),
-            "DECR" => Ok(CommandType::DECR),
-            "INCRBY" => Ok(CommandType::INCRBY),
-            "DECRBY" => Ok(CommandType::DECRBY),
-            "LPUSH" => Ok(CommandType::LPUSH),
-            "LPOP" => Ok(CommandType::LPOP),
+            s if STRING_COMMANDS.contains(&s) => {
+                Ok(CommandType::STRING(StringCommandType::from_str(s)?))
+            }
+            s if LIST_COMMANDS.contains(&s) => Ok(CommandType::LIST(ListCommandType::from_str(s)?)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromStr for StringCommandType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<StringCommandType, Self::Err> {
+        match s {
+            "SET" => Ok(StringCommandType::SET),
+            "GET" => Ok(StringCommandType::GET),
+            "INCR" => Ok(StringCommandType::INCR),
+            "DECR" => Ok(StringCommandType::DECR),
+            "INCRBY" => Ok(StringCommandType::INCRBY),
+            "DECRBY" => Ok(StringCommandType::DECRBY),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromStr for ListCommandType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<ListCommandType, Self::Err> {
+        match s {
+            "LPUSH" => Ok(ListCommandType::LPUSH),
+            "LPOP" => Ok(ListCommandType::LPOP),
             _ => Err(()),
         }
     }

--- a/src/execution_result/mod.rs
+++ b/src/execution_result/mod.rs
@@ -4,15 +4,10 @@ mod error;
 pub use error::ErrorResult;
 mod ping;
 pub use ping::PingResult;
-mod set;
-pub use set::SetResult;
-mod get;
-pub use get::GetResult;
-mod int_op;
-pub use int_op::IntOpResult;
 mod types;
 pub use types::ResultType;
 mod bulk_string;
 pub use bulk_string::BulkStringResult;
 
 pub mod list;
+pub mod string;

--- a/src/execution_result/string/get.rs
+++ b/src/execution_result/string/get.rs
@@ -1,11 +1,11 @@
-use super::{ExecutionResult, ResultType};
+use crate::execution_result::{ExecutionResult, ResultType};
 
 pub struct GetResult {
     pub value: Option<String>,
 }
 
 impl ExecutionResult for GetResult {
-    fn get_result_type(&self) -> super::ResultType {
+    fn get_result_type(&self) -> ResultType {
         match self.value {
             Some(_) => ResultType::SimpleString,
             None => ResultType::Null,

--- a/src/execution_result/string/int_op.rs
+++ b/src/execution_result/string/int_op.rs
@@ -1,11 +1,11 @@
-use super::{ExecutionResult, ResultType};
+use crate::execution_result::{ExecutionResult, ResultType};
 
 pub struct IntOpResult {
     pub value: i64,
 }
 
 impl ExecutionResult for IntOpResult {
-    fn get_result_type(&self) -> super::ResultType {
+    fn get_result_type(&self) -> ResultType {
         ResultType::Integer
     }
     fn to_string(&self) -> String {

--- a/src/execution_result/string/mod.rs
+++ b/src/execution_result/string/mod.rs
@@ -1,0 +1,6 @@
+mod get;
+pub use get::GetResult;
+mod int_op;
+pub use int_op::IntOpResult;
+mod set;
+pub use set::SetResult;

--- a/src/execution_result/string/set.rs
+++ b/src/execution_result/string/set.rs
@@ -1,9 +1,9 @@
-use super::{ExecutionResult, ResultType};
+use crate::execution_result::{ExecutionResult, ResultType};
 
 pub struct SetResult;
 
 impl ExecutionResult for SetResult {
-    fn get_result_type(&self) -> super::ResultType {
+    fn get_result_type(&self) -> ResultType {
         ResultType::SimpleString
     }
     fn to_string(&self) -> String {


### PR DESCRIPTION
Move string operations into a module and split the match statements in `CommandFactory` and `CommandType` for better organisation.