### PR TITLE
Further generalise result serialisation

### DIFF
--- a/src/execution_result/base.rs
+++ b/src/execution_result/base.rs
@@ -2,31 +2,3 @@ pub trait ExecutionResult {
     fn to_string(&self) -> String;
     fn serialise(&self) -> String;
 }
-
-pub fn to_simple_string(value: &String) -> String {
-    format!("+{}\r\n", value)
-}
-
-pub fn to_simple_error(value: &String) -> String {
-    format!("-{}\r\n", value)
-}
-
-pub fn to_null() -> String {
-    "_\r\n".to_string()
-}
-
-pub fn to_integer(value: &String) -> String {
-    format!(":{}\r\n", value)
-}
-
-pub fn to_bulk_string(value: &String) -> String {
-    format!("${}\r\n{}\r\n", value.len(), value)
-}
-
-pub fn to_array(values: &Vec<String>) -> String {
-    let mut res = format!("*{}\r\n", values.len());
-    for v in values {
-        res += to_bulk_string(v).as_str();
-    }
-    res
-}

--- a/src/execution_result/error.rs
+++ b/src/execution_result/error.rs
@@ -1,4 +1,4 @@
-use crate::execution_result::{to_simple_error, ExecutionResult};
+use crate::execution_result::{ExecutionResult, RespReply, SimpleErrorReply};
 
 pub struct ErrorResult {
     pub message: String,
@@ -9,6 +9,9 @@ impl ExecutionResult for ErrorResult {
         self.message.clone()
     }
     fn serialise(&self) -> String {
-        to_simple_error(&self.to_string())
+        SimpleErrorReply {
+            message: self.to_string(),
+        }
+        .serialise()
     }
 }

--- a/src/execution_result/list/lpush.rs
+++ b/src/execution_result/list/lpush.rs
@@ -1,4 +1,4 @@
-use crate::execution_result::{to_integer, ExecutionResult};
+use crate::execution_result::{ExecutionResult, IntegerReply, RespReply};
 
 pub struct LpushResult {
     pub value: usize,
@@ -9,6 +9,9 @@ impl ExecutionResult for LpushResult {
         self.value.to_string()
     }
     fn serialise(&self) -> String {
-        to_integer(&self.to_string())
+        IntegerReply {
+            value: self.value as i64,
+        }
+        .serialise()
     }
 }

--- a/src/execution_result/mod.rs
+++ b/src/execution_result/mod.rs
@@ -1,5 +1,7 @@
 mod base;
 pub use base::*;
+mod reply;
+pub use reply::*;
 mod error;
 pub use error::ErrorResult;
 mod ping;

--- a/src/execution_result/ping.rs
+++ b/src/execution_result/ping.rs
@@ -1,11 +1,14 @@
 pub struct PingResult;
-use crate::execution_result::{to_simple_string, ExecutionResult};
+use crate::execution_result::{ExecutionResult, RespReply, SimpleStringReply};
 
 impl ExecutionResult for PingResult {
     fn to_string(&self) -> String {
         "OK".to_string()
     }
     fn serialise(&self) -> String {
-        to_simple_string(&self.to_string())
+        SimpleStringReply {
+            value: "OK".to_string(),
+        }
+        .serialise()
     }
 }

--- a/src/execution_result/reply.rs
+++ b/src/execution_result/reply.rs
@@ -1,0 +1,61 @@
+pub trait RespReply {
+    fn serialise(&self) -> String;
+}
+
+pub struct SimpleStringReply {
+    pub value: String,
+}
+
+impl RespReply for SimpleStringReply {
+    fn serialise(&self) -> String {
+        format!("+{}\r\n", &self.value)
+    }
+}
+
+pub struct SimpleErrorReply {
+    pub message: String,
+}
+
+impl RespReply for SimpleErrorReply {
+    fn serialise(&self) -> String {
+        format!("-{}\r\n", &self.message)
+    }
+}
+
+pub struct NullReply;
+impl RespReply for NullReply {
+    fn serialise(&self) -> String {
+        "_\r\n".to_string()
+    }
+}
+
+pub struct IntegerReply {
+    pub value: i64,
+}
+impl RespReply for IntegerReply {
+    fn serialise(&self) -> String {
+        format!(":{}\r\n", self.value)
+    }
+}
+
+pub struct BulkStringReply {
+    pub value: String,
+}
+impl RespReply for BulkStringReply {
+    fn serialise(&self) -> String {
+        format!("${}\r\n{}\r\n", self.value.len(), &self.value)
+    }
+}
+
+pub struct ArrayReply {
+    pub values: Vec<Box<dyn RespReply>>,
+}
+impl RespReply for ArrayReply {
+    fn serialise(&self) -> String {
+        let mut res = format!("*{}\r\n", self.values.len());
+        for v in &self.values {
+            res += v.serialise().as_str();
+        }
+        res
+    }
+}

--- a/src/execution_result/string/get.rs
+++ b/src/execution_result/string/get.rs
@@ -1,4 +1,4 @@
-use crate::execution_result::{to_null, to_simple_string, ExecutionResult};
+use crate::execution_result::{ExecutionResult, NullReply, RespReply, SimpleStringReply};
 
 pub struct GetResult {
     pub value: Option<String>,
@@ -13,8 +13,8 @@ impl ExecutionResult for GetResult {
     }
     fn serialise(&self) -> String {
         match &self.value {
-            Some(v) => to_simple_string(v),
-            None => to_null(),
+            Some(v) => SimpleStringReply { value: v.clone() }.serialise(),
+            None => NullReply {}.serialise(),
         }
     }
 }

--- a/src/execution_result/string/int_op.rs
+++ b/src/execution_result/string/int_op.rs
@@ -1,4 +1,4 @@
-use crate::execution_result::{to_integer, ExecutionResult};
+use crate::execution_result::{ExecutionResult, IntegerReply, RespReply};
 
 pub struct IntOpResult {
     pub value: i64,
@@ -9,6 +9,6 @@ impl ExecutionResult for IntOpResult {
         self.value.to_string()
     }
     fn serialise(&self) -> String {
-        to_integer(&self.to_string())
+        IntegerReply { value: self.value }.serialise()
     }
 }

--- a/src/execution_result/string/set.rs
+++ b/src/execution_result/string/set.rs
@@ -1,4 +1,4 @@
-use crate::execution_result::{to_simple_string, ExecutionResult};
+use crate::execution_result::{ExecutionResult, RespReply, SimpleStringReply};
 
 pub struct SetResult;
 
@@ -7,6 +7,9 @@ impl ExecutionResult for SetResult {
         "OK".to_string()
     }
     fn serialise(&self) -> String {
-        to_simple_string(&self.to_string())
+        SimpleStringReply {
+            value: self.to_string(),
+        }
+        .serialise()
     }
 }


### PR DESCRIPTION
Improve the implementation in #43 for flexibility. Since it's actually possible to mix reply types in arrays, the code needs to be more flexible. In #43, all elements are assumed to be bulk strings. In this PR, elements can be of any reply type.