### PR TITLE
Implement SMEMBERS command

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -129,11 +129,15 @@ fn handle_set_command(
     body: Vec<String>,
 ) -> Result<Box<dyn Command>, RequestError> {
     match v {
-        SetCommandType::SAdd => match set::SAddCommand::new(body) {
+        SetCommandType::Add => match set::SAddCommand::new(body) {
             Ok(v) => Ok(v),
             Err(e) => Err(e),
         },
-        SetCommandType::SRem => match set::SRemCommand::new(body) {
+        SetCommandType::Rem => match set::SRemCommand::new(body) {
+            Ok(v) => Ok(v),
+            Err(e) => Err(e),
+        },
+        SetCommandType::Members => match set::SMembersCommand::new(body) {
             Ok(v) => Ok(v),
             Err(e) => Err(e),
         },

--- a/src/command/set/mod.rs
+++ b/src/command/set/mod.rs
@@ -2,3 +2,5 @@ mod sadd;
 pub use sadd::SAddCommand;
 mod srem;
 pub use srem::SRemCommand;
+mod smembers;
+pub use smembers::SMembersCommand;

--- a/src/command/set/smembers.rs
+++ b/src/command/set/smembers.rs
@@ -1,0 +1,82 @@
+use crate::command::Command;
+use crate::data_store::DataStore;
+use crate::error::RequestError;
+use crate::execution_result::set::SMembersResult;
+use crate::execution_result::ExecutionResult;
+
+#[derive(Debug)]
+pub struct SMembersCommand {
+    key: String,
+}
+
+impl SMembersCommand {
+    pub fn new(tokens: Vec<String>) -> Result<Box<Self>, RequestError> {
+        if tokens.len() != 1 {
+            return Err(RequestError::IncorrectArgCount);
+        }
+        Ok(Box::new(SMembersCommand {
+            key: tokens[0].clone(),
+        }))
+    }
+}
+
+impl Command for SMembersCommand {
+    fn execute(
+        &self,
+        data_store: &mut DataStore,
+    ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
+        match data_store.get_set_mut(&self.key) {
+            Ok(set_op) => {
+                let mut values = vec![];
+                if let Some(set) = set_op {
+                    for v in set.iter() {
+                        values.push(v.to_owned());
+                    }
+                }
+                Ok(Box::new(SMembersResult { values }))
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::command::set::{SAddCommand, SMembersCommand};
+    use crate::command::Command;
+    use crate::data_store::DataStore;
+
+    #[test]
+    fn should_accept_one_token() {
+        let err = SMembersCommand::new(vec!["foo".to_string(), "bar".to_string()])
+            .err()
+            .unwrap();
+        assert_eq!(
+            err.to_string(),
+            "ERR wrong number of arguments for command".to_string()
+        );
+        let v = SMembersCommand::new(vec!["foo".to_string()]).unwrap();
+        assert_eq!(v.key, "foo".to_string());
+    }
+
+    #[test]
+    fn should_return_empty_list_if_key_does_not_exist() {
+        let cmd = SMembersCommand::new(vec!["foo".to_string()]).unwrap();
+        let mut ds = DataStore::new();
+        let result = cmd.execute(&mut ds);
+        assert_eq!(result.unwrap().to_string(), "".to_string());
+    }
+
+    #[test]
+    fn should_return_elements() {
+        let key = "foo".to_string();
+        let mut ds = DataStore::new();
+        SAddCommand::new(vec![key.clone(), "v1".to_string(), "v2".to_string()])
+            .unwrap()
+            .execute(&mut ds)
+            .unwrap();
+        let cmd = SMembersCommand::new(vec![key.clone()]).unwrap();
+        let result = cmd.execute(&mut ds);
+        assert_eq!(result.unwrap().to_string(), "v1,v2".to_string());
+    }
+}

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -21,8 +21,9 @@ pub enum ListCommandType {
 }
 
 pub enum SetCommandType {
-    SAdd,
-    SRem,
+    Add,
+    Rem,
+    Members,
 }
 
 pub enum CommandType {
@@ -36,7 +37,7 @@ const STRING_COMMANDS: &[&str] = &[
     "set", "get", "incr", "decr", "incrby", "decrby", "mget", "mset",
 ];
 const LIST_COMMANDS: &[&str] = &["lpush", "lpop", "lrange", "llen", "rpush", "rpop"];
-const SET_COMMANDS: &[&str] = &["sadd", "srem"];
+const SET_COMMANDS: &[&str] = &["sadd", "srem", "smembers"];
 
 impl FromStr for CommandType {
     type Err = ();
@@ -93,8 +94,9 @@ impl FromStr for SetCommandType {
 
     fn from_str(s: &str) -> Result<SetCommandType, Self::Err> {
         match s {
-            "sadd" => Ok(SetCommandType::SAdd),
-            "srem" => Ok(SetCommandType::SRem),
+            "sadd" => Ok(SetCommandType::Add),
+            "srem" => Ok(SetCommandType::Rem),
+            "smembers" => Ok(SetCommandType::Members),
             _ => Err(()),
         }
     }

--- a/src/execution_result/set/mod.rs
+++ b/src/execution_result/set/mod.rs
@@ -2,3 +2,5 @@ mod sadd;
 pub use sadd::SAddResult;
 mod srem;
 pub use srem::SRemResult;
+mod smembers;
+pub use smembers::SMembersResult;

--- a/src/execution_result/set/smembers.rs
+++ b/src/execution_result/set/smembers.rs
@@ -1,0 +1,20 @@
+use crate::execution_result::{ArrayReply, BulkStringReply, ExecutionResult, RespReply};
+
+pub struct SMembersResult {
+    pub values: Vec<String>,
+}
+
+impl ExecutionResult for SMembersResult {
+    fn to_string(&self) -> String {
+        self.values.to_vec().join(",")
+    }
+    fn serialise(&self) -> String {
+        let mut replies: Vec<Box<dyn RespReply>> = Vec::new();
+        for value in &self.values {
+            replies.push(Box::new(BulkStringReply {
+                value: value.clone(),
+            }));
+        }
+        ArrayReply { values: replies }.serialise()
+    }
+}


### PR DESCRIPTION
Closes #61.

Note that the change in `SetCommandType` is because clippy raised a warning for all enum values starting with the same letter `S`.