### PR TITLE
Refactor hash commands for better result handling

### DIFF
--- a/src/command/hash/hget.rs
+++ b/src/command/hash/hget.rs
@@ -26,15 +26,13 @@ impl Command for HGetCommand {
         &self,
         data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        match data_store.get_hash_mut(&self.key) {
-            Ok(hash_op) => Ok(Box::new(HGetResult {
-                value: match hash_op {
-                    Some(hash) => hash.get(&self.field).cloned(),
-                    None => None,
-                },
-            })),
-            Err(e) => Err(e),
-        }
+        let hash_op = data_store.get_hash_mut(&self.key)?;
+        Ok(Box::new(HGetResult {
+            value: match hash_op {
+                Some(hash) => hash.get(&self.field).cloned(),
+                None => None,
+            },
+        }))
     }
 }
 

--- a/src/command/hash/hgetall.rs
+++ b/src/command/hash/hgetall.rs
@@ -62,17 +62,19 @@ mod test {
         let key = "foo".to_string();
         HSetCommand::new(vec![
             key.clone(),
-            "k1".to_string(),
-            "v1".to_string(),
-            "k2".to_string(),
-            "v2".to_string(),
+            "a0".to_string(),
+            "a1".to_string(),
+            "b0".to_string(),
+            "b1".to_string(),
         ])
         .unwrap()
         .execute(&mut ds)
         .unwrap();
         let cmd = HGetAllCommand::new(vec![key.clone()]).unwrap();
-        let result = cmd.execute(&mut ds);
-        assert_eq!(result.unwrap().to_string(), "k1,v1,k2,v2".to_string());
+        let result = cmd.execute(&mut ds).unwrap().to_string();
+        let mut tokens = result.split(",").collect::<Vec<_>>();
+        tokens.sort();
+        assert_eq!(tokens.join(","), "a0,a1,b0,b1".to_string());
     }
 
     #[test]

--- a/src/command/hash/hgetall.rs
+++ b/src/command/hash/hgetall.rs
@@ -62,19 +62,39 @@ mod test {
         let key = "foo".to_string();
         HSetCommand::new(vec![
             key.clone(),
-            "a0".to_string(),
-            "a1".to_string(),
-            "b0".to_string(),
-            "b1".to_string(),
+            "k1".to_string(),
+            "v1".to_string(),
+            "k2".to_string(),
+            "v2".to_string(),
         ])
         .unwrap()
         .execute(&mut ds)
         .unwrap();
         let cmd = HGetAllCommand::new(vec![key.clone()]).unwrap();
         let result = cmd.execute(&mut ds).unwrap().to_string();
-        let mut tokens = result.split(",").collect::<Vec<_>>();
-        tokens.sort();
-        assert_eq!(tokens.join(","), "a0,a1,b0,b1".to_string());
+        let tokens = result.split(',').collect::<Vec<_>>();
+
+        // Since key-value pairs might not be returned in the order that they were inserted,
+        // we check the pairs by first locating the keys and then examining the next element.
+        let mut k1_idx = tokens.len();
+        for (i, token) in tokens.iter().enumerate() {
+            if token == &"k1" {
+                k1_idx = i;
+                break;
+            }
+        }
+        assert_ne!(k1_idx, tokens.len());
+        assert_eq!(tokens[k1_idx + 1], "v1".to_string());
+
+        let mut k2_idx = tokens.len();
+        for (i, token) in tokens.iter().enumerate() {
+            if token == &"k2" {
+                k2_idx = i;
+                break;
+            }
+        }
+        assert_ne!(k2_idx, tokens.len());
+        assert_eq!(tokens[k2_idx + 1], "v2".to_string());
     }
 
     #[test]

--- a/src/command/hash/hgetall.rs
+++ b/src/command/hash/hgetall.rs
@@ -24,18 +24,16 @@ impl Command for HGetAllCommand {
         &self,
         data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
-        match data_store.get_hash_mut(&self.key) {
-            Ok(hash_op) => Ok(Box::new(HGetAllResult {
-                values: match hash_op {
-                    Some(hash) => hash
-                        .iter()
-                        .flat_map(|(k, v)| vec![k.clone(), v.clone()])
-                        .collect(),
-                    None => vec![],
-                },
-            })),
-            Err(e) => Err(e),
-        }
+        let hash_op = data_store.get_hash_mut(&self.key)?;
+        Ok(Box::new(HGetAllResult {
+            values: match hash_op {
+                Some(hash) => hash
+                    .iter()
+                    .flat_map(|(k, v)| vec![k.clone(), v.clone()])
+                    .collect(),
+                None => vec![],
+            },
+        }))
     }
 }
 

--- a/src/command/hash/hset.rs
+++ b/src/command/hash/hset.rs
@@ -32,26 +32,21 @@ impl Command for HSetCommand {
         data_store: &mut DataStore,
     ) -> Result<Box<dyn ExecutionResult>, Box<dyn std::error::Error>> {
         // TODO: atomicity
-        match data_store.get_hash_mut(&self.key) {
-            Ok(hash_op) => {
-                let hash = match hash_op {
-                    Some(hash) => hash,
-                    None => {
-                        let _ = data_store.insert_hash(&self.key);
-                        data_store.get_hash_mut(&self.key).unwrap().unwrap()
-                    }
-                };
-                let mut count = 0;
-                for (key, value) in &self.values {
-                    count += match hash.insert(key.clone(), value.clone()) {
-                        Some(_) => 0,
-                        None => 1,
-                    }
-                }
-                Ok(Box::new(HSetResult { value: count }))
+        let hash = match data_store.get_hash_mut(&self.key)? {
+            Some(hash) => hash,
+            None => {
+                let _ = data_store.insert_hash(&self.key);
+                data_store.get_hash_mut(&self.key).unwrap().unwrap()
             }
-            Err(e) => Err(e),
+        };
+        let mut count = 0;
+        for (key, value) in &self.values {
+            count += match hash.insert(key.clone(), value.clone()) {
+                Some(_) => 0,
+                None => 1,
+            }
         }
+        Ok(Box::new(HSetResult { value: count }))
     }
 }
 


### PR DESCRIPTION
Use `?` to simplify `match data_store.get_hash_mut(&self.key)`.

Also fixed a flaky test in `HGETALL`.