### PR TITLE
Implement radix tree

### DIFF
--- a/src/data_store/mod.rs
+++ b/src/data_store/mod.rs
@@ -1,4 +1,5 @@
 mod sorted_set;
+mod stream;
 
 use crate::error::{ExecutionError, InternalError};
 

--- a/src/data_store/stream/mod.rs
+++ b/src/data_store/stream/mod.rs
@@ -1,0 +1,3 @@
+mod radix_tree;
+use radix_tree::RadixTree;
+mod tree_node;

--- a/src/data_store/stream/radix_tree.rs
+++ b/src/data_store/stream/radix_tree.rs
@@ -1,4 +1,4 @@
-use std::{borrow::BorrowMut, cell::RefCell, collections::HashMap};
+use std::collections::HashMap;
 
 use super::tree_node::{TreeNode, TreeNodeId};
 use crate::error::StreamError;
@@ -33,7 +33,7 @@ impl RadixTree {
         let mut words = new_id.words();
         let word = words.next().unwrap();
         self.root
-            .insert_child(word, words, new_id.clone(), Some(values));
+            .insert_child(word, words, new_id.clone(), Some(values))?;
         self.top_id = new_id;
         Ok(())
     }

--- a/src/data_store/stream/radix_tree.rs
+++ b/src/data_store/stream/radix_tree.rs
@@ -24,7 +24,10 @@ impl RadixTree {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let new_id = match id {
             Some(v) => TreeNodeId(v),
-            None => self.top_id.incr()?,
+            None => match self.top_id.incr() {
+                Ok(v) => v,
+                Err(_) => return Err(Box::new(StreamError::IdExhausted)),
+            },
         };
         if new_id <= self.top_id {
             return Err(Box::new(StreamError::IdNotGreaterThanStreamTop));

--- a/src/data_store/stream/radix_tree.rs
+++ b/src/data_store/stream/radix_tree.rs
@@ -37,4 +37,9 @@ impl RadixTree {
         self.top_id = new_id;
         Ok(())
     }
+
+    pub fn remove(&mut self, id: [u64; 2]) {
+        let id = TreeNodeId(id);
+        self.root.remove_child(id.words());
+    }
 }

--- a/src/data_store/stream/radix_tree.rs
+++ b/src/data_store/stream/radix_tree.rs
@@ -1,0 +1,40 @@
+use std::{borrow::BorrowMut, cell::RefCell, collections::HashMap};
+
+use super::tree_node::{TreeNode, TreeNodeId};
+use crate::error::StreamError;
+
+pub struct RadixTree {
+    root: Box<TreeNode>,
+    top_id: TreeNodeId,
+}
+
+impl RadixTree {
+    pub fn new() -> Self {
+        let top_id = TreeNodeId([0, 0]);
+        RadixTree {
+            root: Box::new(TreeNode::new(None, 0, None, HashMap::new())),
+            top_id,
+        }
+    }
+
+    pub fn insert(
+        &mut self,
+        id: Option<[u64; 2]>,
+        values: Vec<[String; 2]>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let new_id = match id {
+            Some(v) => TreeNodeId(v),
+            None => self.top_id.incr()?,
+        };
+        if new_id <= self.top_id {
+            return Err(Box::new(StreamError::IdNotGreaterThanStreamTop));
+        }
+
+        let mut words = new_id.words();
+        let word = words.next().unwrap();
+        self.root
+            .insert_child(word, words, new_id.clone(), Some(values));
+        self.top_id = new_id;
+        Ok(())
+    }
+}

--- a/src/data_store/stream/tree_node.rs
+++ b/src/data_store/stream/tree_node.rs
@@ -27,8 +27,11 @@ impl TreeNode {
         }
     }
 
-    fn get_child(&self, key: &u8) -> Option<&Box<TreeNode>> {
-        self.children.get(key)
+    fn get_child(&self, key: &u8) -> Option<&TreeNode> {
+        match self.children.get(key) {
+            Some(v) => Some(v),
+            None => None
+        }
     }
 
     fn get_child_mut(&mut self, key: &u8) -> Option<&mut Box<TreeNode>> {
@@ -236,7 +239,7 @@ mod test {
     mod test_node {
         use std::collections::HashMap;
 
-        use crate::data_store::stream::tree_node::{TreeNode, TreeNodeId, TreeNodeIdIterator};
+        use crate::data_store::stream::tree_node::{TreeNode, TreeNodeId};
 
         #[test]
         fn should_insert_child() {

--- a/src/data_store/stream/tree_node.rs
+++ b/src/data_store/stream/tree_node.rs
@@ -1,0 +1,243 @@
+use crate::error::StreamError;
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+pub struct TreeNode {
+    pub id: Option<TreeNodeId>,
+    key: u8,
+    values: Option<Vec<[String; 2]>>,
+    children: HashMap<u8, Box<TreeNode>>,
+}
+
+impl TreeNode {
+    pub fn new(
+        id: Option<TreeNodeId>,
+        key: u8,
+        values: Option<Vec<[String; 2]>>,
+        children: HashMap<u8, Box<TreeNode>>,
+    ) -> Self {
+        Self {
+            id,
+            key,
+            values,
+            children,
+        }
+    }
+
+    pub fn next(&self, key: &u8) -> Option<&Box<TreeNode>> {
+        self.children.get(key)
+    }
+
+    pub fn get_child(&self, key: &u8) -> Option<&Box<TreeNode>> {
+        self.children.get(key)
+    }
+
+    pub fn insert_child(
+        &mut self,
+        key: u8,
+        mut words: TreeNodeIdIterator,
+        id: TreeNodeId,
+        values: Option<Vec<[String; 2]>>,
+    ) {
+        match words.next() {
+            Some(word) => {
+                let node = match self.children.get_mut(&key) {
+                    Some(v) => v,
+                    None => {
+                        self.children.insert(
+                            key,
+                            Box::new(TreeNode::new(None, key, None, HashMap::new())),
+                        );
+                        self.children.get_mut(&key).unwrap()
+                    }
+                };
+                node.insert_child(word, words, id, values);
+            }
+            None => {
+                self.children.insert(
+                    key,
+                    Box::new(TreeNode::new(Some(id), key, values, HashMap::new())),
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TreeNodeId(pub [u64; 2]); // id[0] == bits 128 - 255
+
+impl TreeNodeId {
+    pub fn words(&self) -> TreeNodeIdIterator {
+        // convert id to big endian: reorder words in each part and swap high and low parts
+        let mut curr = [self[1], self[0]];
+        let mut id = TreeNodeId([0, 0]);
+        for _ in 0..8 {
+            for i in 0..2 {
+                id[i] = (id[i] << 8) | (curr[i] & 0xff);
+                curr[i] >>= 8;
+            }
+        }
+        TreeNodeIdIterator { id, ptr: 0 }
+    }
+
+    pub fn incr(&self) -> Result<TreeNodeId, Box<dyn std::error::Error>> {
+        if let Some(v) = self[1].checked_add(1) {
+            Ok(TreeNodeId([self[0], v]))
+        } else {
+            if let Some(v) = self[0].checked_add(1) {
+                Ok(TreeNodeId([v, 0]))
+            } else {
+                Err(Box::new(StreamError::IdExhausted))
+            }
+        }
+    }
+}
+
+impl Clone for TreeNodeId {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl Deref for TreeNodeId {
+    type Target = [u64; 2];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TreeNodeId {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl PartialEq for TreeNodeId {
+    fn eq(&self, other: &Self) -> bool {
+        self[0] == other[0] && self[1] == other[1]
+    }
+}
+
+impl PartialOrd for TreeNodeId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self == other {
+            Some(std::cmp::Ordering::Equal)
+        } else if self[0] < other[0] || self[0] == other[0] && self[1] < other[1] {
+            Some(std::cmp::Ordering::Less)
+        } else {
+            Some(std::cmp::Ordering::Greater)
+        }
+    }
+}
+
+pub struct TreeNodeIdIterator {
+    // ID in big endian
+    id: TreeNodeId,
+    ptr: u8,
+}
+
+impl Iterator for TreeNodeIdIterator {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ptr == 128 {
+            return None;
+        }
+        self.ptr += 8;
+        if self.ptr <= 64 {
+            let v = (self.id[1] & 0xff) as u8;
+            self.id[1] >>= 8;
+            Some(v)
+        } else {
+            let v = (self.id[0] & 0xff) as u8;
+            self.id[0] >>= 8;
+            Some(v)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    mod test_id_iterator {
+        use crate::data_store::stream::tree_node::{TreeNodeId, TreeNodeIdIterator};
+
+        #[test]
+        fn should_return_values_in_order() {
+            let words = TreeNodeIdIterator {
+                id: TreeNodeId([0x0908070605040302, 0xf9f8f7f6f5f4f3f2]),
+                ptr: 0,
+            };
+            let values = words.collect::<Vec<u8>>();
+            assert_eq!(
+                values,
+                [0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 2, 3, 4, 5, 6, 7, 8, 9]
+            );
+        }
+    }
+
+    mod test_id {
+        use crate::data_store::stream::tree_node::TreeNodeId;
+
+        #[test]
+        fn should_return_words_in_big_endian() {
+            let id = TreeNodeId([0x0908070605040302, 0xf9f8f7f6f5f4f3f2]);
+            let values = id.words().collect::<Vec<u8>>();
+            assert_eq!(
+                values,
+                [9, 8, 7, 6, 5, 4, 3, 2, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2]
+            );
+        }
+
+        #[test]
+        fn should_return_incr() {
+            let id = TreeNodeId([0, 0]);
+            assert_eq!(id.incr().unwrap(), TreeNodeId([0, 1]));
+
+            let id = TreeNodeId([0, u64::MAX]);
+            assert_eq!(id.incr().unwrap(), TreeNodeId([1, 0]));
+
+            let id = TreeNodeId([u64::MAX, u64::MAX]);
+            assert_eq!(
+                id.incr().err().unwrap().to_string(),
+                "The stream has exhausted the last possible ID, unable to add more items"
+            );
+        }
+    }
+
+    mod test_node {
+        use std::collections::HashMap;
+
+        use crate::data_store::stream::tree_node::{TreeNode, TreeNodeId, TreeNodeIdIterator};
+
+        #[test]
+        fn should_insert_child() {
+            let id = TreeNodeId([0x0908070605040302, 0xf9f8f7f6f5f4f3f2]);
+            let mut words = TreeNodeIdIterator {
+                id: id.clone(),
+                ptr: 0,
+            };
+            let key = words.next().unwrap();
+            let values = vec![["foo".to_string(), "bar".to_string()]];
+            let mut root = TreeNode::new(None, 0, None, HashMap::new());
+            root.insert_child(key, words, id, Some(values.clone()));
+            let expected_keys = [
+                0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 2, 3, 4, 5, 6, 7, 8,
+            ];
+            let mut node = &root;
+            for k in expected_keys {
+                node = node.get_child(&k).unwrap();
+                // All non-leaf nodes should not have any values or id
+                assert_eq!(node.key, k);
+                assert!(node.values.is_none());
+                assert!(node.id.is_none());
+                assert_eq!(node.children.len(), 1)
+            }
+            node = node.get_child(&9).unwrap();
+            assert_eq!(node.key, 9);
+            assert_eq!(node.values.as_ref().unwrap(), &values);
+            assert_eq!(node.children.len(), 0);
+        }
+    }
+}

--- a/src/data_store/stream/tree_node.rs
+++ b/src/data_store/stream/tree_node.rs
@@ -1,4 +1,4 @@
-use crate::error::{InternalError, StreamError};
+use crate::error::InternalError;
 use std::{
     collections::HashMap,
     fmt::Display,
@@ -30,7 +30,7 @@ impl TreeNode {
     fn get_child(&self, key: &u8) -> Option<&TreeNode> {
         match self.children.get(key) {
             Some(v) => Some(v),
-            None => None
+            None => None,
         }
     }
 
@@ -108,13 +108,13 @@ impl TreeNodeId {
         TreeNodeIdIterator { id, ptr: 0 }
     }
 
-    pub fn incr(&self) -> Result<TreeNodeId, Box<dyn std::error::Error>> {
+    pub fn incr(&self) -> Result<TreeNodeId, ()> {
         if let Some(v) = self[1].checked_add(1) {
             Ok(TreeNodeId([self[0], v]))
         } else if let Some(v) = self[0].checked_add(1) {
             Ok(TreeNodeId([v, 0]))
         } else {
-            Err(Box::new(StreamError::IdExhausted))
+            Err(())
         }
     }
 }
@@ -229,10 +229,7 @@ mod test {
             assert_eq!(id.incr().unwrap(), TreeNodeId([1, 0]));
 
             let id = TreeNodeId([u64::MAX, u64::MAX]);
-            assert_eq!(
-                id.incr().err().unwrap().to_string(),
-                "The stream has exhausted the last possible ID, unable to add more items"
-            );
+            assert!(id.incr().is_err());
         }
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -49,11 +49,3 @@ pub enum HIncrByCommandError {
     #[error("hash value is not an integer")]
     InvalidHashValue,
 }
-
-#[derive(Error, Debug)]
-pub enum StreamError {
-    #[error("The ID specified in XADD is equal or smaller than the target stream top item")]
-    IdNotGreaterThanStreamTop,
-    #[error("The stream has exhausted the last possible ID, unable to add more items")]
-    IdExhausted,
-}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -49,3 +49,11 @@ pub enum HIncrByCommandError {
     #[error("hash value is not an integer")]
     InvalidHashValue,
 }
+
+#[derive(Error, Debug)]
+pub enum StreamError {
+    #[error("The ID specified in XADD is equal or smaller than the target stream top item")]
+    IdNotGreaterThanStreamTop,
+    #[error("The stream has exhausted the last possible ID, unable to add more items")]
+    IdExhausted,
+}


### PR DESCRIPTION
Closes #98.

Each tree node holds a `u8` key, a segment of the element ID `[u64; 2]` as what redis has now. This implementation does not compress nodes with only one leaf.